### PR TITLE
Allow additional fields when a schema cycle is detected

### DIFF
--- a/pkg/schemas/openapi/generate.go
+++ b/pkg/schemas/openapi/generate.go
@@ -160,6 +160,9 @@ func schemaToProps(schema *types.Schema, schemas *types.Schemas, inflight map[st
 	}
 
 	if inflight[schema.ID] {
+		jsp.AdditionalProperties = &v1.JSONSchemaPropsOrBool{
+			Allows: true,
+		}
 		return jsp, nil
 	}
 


### PR DESCRIPTION
Previously, when a schema cycle was detected during CRD generation, the generator would return an empty object schema. This is mostly fine because:
1. Kubernetes doesn't support $ref in their API schemas
2. Trying to copy the existing schema would result in a stack overflow error when trying to parse the JSON for an object

The only downfall of this approach is that nothing will get saved to etcd for the cycled schema. Meaning that, all fields would be ignored by Kubernetes and nothing would get saved.

Let's say a schema exists like:

```go
type Employee struct {
    metav1.TypeMeta `json:",inline"`
    metav1.ListMeta `json:"metadata,omitempty"`

    Manager Employee `json:"manager"`
}
```

Then, after generating the corresponding CRD with the existing code, the Manager field will always be empty in etcd.

After this change, the cycle will still be detected in the same way, but the resulting schema will allow additional fields. Kubernetes will skip the validation of fields and the object will get successfully saved to Kubernetes. For the example above, this means that it would be possible to save fields to etcd for the Manager field. These fields would not be validated by Kubernetes, but the JSON decoding would handle it properly and updates to the object will ensure it has the desired fields.